### PR TITLE
Add menu for encoding or decoding

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,26 +59,51 @@ def show_all_shifts(shifts):
     for shift, shifted_text in shifts.items():
         print(f"Shift {shift}: {shifted_text}")
 
-# Get input from the user
-cipher_text = input("Enter the ciphered text: ")
-alphabet_input = input("Any specific alphabet to use when decoding? (leave blank for default abcdefghijklmnopqrstuvwxyz alphabet): ")
 
-# If no alphabet is provided, use the default alphabet
-if not alphabet_input:
-    alphabet_input = "abcdefghijklmnopqrstuvwxyz"
+def encode_menu():
+    text = input("Enter the text to encode: ")
+    shift = int(input("Enter the shift value: "))
+    alphabet_input = input(
+        "Any specific alphabet to use when encoding? (leave blank for default abcdefghijklmnopqrstuvwxyz alphabet): "
+    )
+    if not alphabet_input:
+        alphabet_input = "abcdefghijklmnopqrstuvwxyz"
+    encoded = caesar_cipher(text, shift, alphabet_input)
+    print(f"Encoded text: {encoded}")
 
-# Generate all shifts using the provided or default alphabet
-shifts = caesar_cipher_shifts(cipher_text, alphabet_input)
 
-# Specify the words file path (ensure 'words.txt' exists in your directory)
-words_file = "words.txt"  # The path to your words file
+def decode_menu():
+    cipher_text = input("Enter the ciphered text: ")
+    alphabet_input = input(
+        "Any specific alphabet to use when decoding? (leave blank for default abcdefghijklmnopqrstuvwxyz alphabet): "
+    )
+    if not alphabet_input:
+        alphabet_input = "abcdefghijklmnopqrstuvwxyz"
 
-# Find the matching shift
-result, shift_used = find_matching_shift(cipher_text, words_file, alphabet_input)
+    shifts = caesar_cipher_shifts(cipher_text, alphabet_input)
+    words_file = "words.txt"  # The path to your words file
+    result, shift_used = find_matching_shift(cipher_text, words_file, alphabet_input)
 
-if result:
-    print(f"\nThe uncease string is found using Shift {shift_used}: {result}")
-else:
-    print("\nNo valid shift found with a majority match in words.txt.")
-    # If no match, show all 26 shifts
-    show_all_shifts(shifts)
+    if result:
+        print(f"\nThe uncease string is found using Shift {shift_used}: {result}")
+    else:
+        print("\nNo valid shift found with a majority match in words.txt.")
+        show_all_shifts(shifts)
+
+
+def main():
+    print("Choose an option:")
+    print("1. Encode text using Caesar cipher")
+    print("2. Decode Caesar cipher")
+    choice = input("Enter 1 or 2: ").strip()
+
+    if choice == "1":
+        encode_menu()
+    elif choice == "2":
+        decode_menu()
+    else:
+        print("Invalid choice.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add interactive menu with options to encode or decode
- preserve existing decode logic for option 2

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7f888a78832296adfaa2e24088f6