### PR TITLE
Improve decode matching and add colorful menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,31 @@
+import os
+import sys
+
+
+def clear_screen():
+    os.system("cls" if os.name == "nt" else "clear")
+
+
+def get_single_key():
+    """Return a single character from standard input without requiring Enter."""
+    if os.name == "nt":
+        import msvcrt
+
+        return msvcrt.getch().decode()
+    else:
+        import tty
+        import termios
+
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        return ch
+
+
 def caesar_cipher(text, shift, alphabet):
     result = []
     alphabet_length = len(alphabet)
@@ -32,10 +60,15 @@ def caesar_cipher_shifts(text, alphabet):
     return shifts
 
 def load_words(file_path):
-    # Read the words from the file and store them in a set for fast lookup
-    with open(file_path, 'r') as file:
-        words = set(line.strip().lower() for line in file.readlines())
-    return words
+    """Load words from file and return a lowercase set."""
+    try:
+        with open(file_path, "r") as file:
+            return set(line.strip().lower() for line in file.readlines())
+    except FileNotFoundError:
+        print(
+            "words.txt not found. Please re-run this with a dictionary inside words.txt or download words.txt from the official repository at github.com/CamDevv/Caesar-Master"
+        )
+        sys.exit(1)
 
 def find_matching_shift(text, words_file, alphabet):
     valid_words = load_words(words_file)
@@ -43,7 +76,8 @@ def find_matching_shift(text, words_file, alphabet):
     
     # Go through each shift and check how many words match
     for shift, shifted_text in shifts.items():
-        shifted_words = shifted_text.lower().split()
+        raw_words = shifted_text.lower().split()
+        shifted_words = ["".join(c for c in word if c.isalpha()) for word in raw_words]
         matched_words = [word for word in shifted_words if word in valid_words]
         
         # Check if majority of the words in the shifted text are in words.txt
@@ -59,26 +93,54 @@ def show_all_shifts(shifts):
     for shift, shifted_text in shifts.items():
         print(f"Shift {shift}: {shifted_text}")
 
-# Get input from the user
-cipher_text = input("Enter the ciphered text: ")
-alphabet_input = input("Any specific alphabet to use when decoding? (leave blank for default abcdefghijklmnopqrstuvwxyz alphabet): ")
 
-# If no alphabet is provided, use the default alphabet
-if not alphabet_input:
-    alphabet_input = "abcdefghijklmnopqrstuvwxyz"
+def encode_menu():
+    text = input("Enter the text to encode: ")
+    shift = int(input("Enter the shift value: "))
+    alphabet_input = input(
+        "Any specific alphabet to use when encoding? (leave blank for default abcdefghijklmnopqrstuvwxyz alphabet): "
+    )
+    if not alphabet_input:
+        alphabet_input = "abcdefghijklmnopqrstuvwxyz"
+    encoded = caesar_cipher(text, shift, alphabet_input)
+    print(f"Encoded text: {encoded}")
 
-# Generate all shifts using the provided or default alphabet
-shifts = caesar_cipher_shifts(cipher_text, alphabet_input)
 
-# Specify the words file path (ensure 'words.txt' exists in your directory)
-words_file = "words.txt"  # The path to your words file
+def decode_menu():
+    cipher_text = input("Enter the ciphered text: ")
+    alphabet_input = input(
+        "Any specific alphabet to use when decoding? (leave blank for default abcdefghijklmnopqrstuvwxyz alphabet): "
+    )
+    if not alphabet_input:
+        alphabet_input = "abcdefghijklmnopqrstuvwxyz"
 
-# Find the matching shift
-result, shift_used = find_matching_shift(cipher_text, words_file, alphabet_input)
+    words_file = "words.txt"
+    shifts = caesar_cipher_shifts(cipher_text, alphabet_input)
+    result, shift_used = find_matching_shift(cipher_text, words_file, alphabet_input)
 
-if result:
-    print(f"\nThe uncease string is found using Shift {shift_used}: {result}")
-else:
-    print("\nNo valid shift found with a majority match in words.txt.")
-    # If no match, show all 26 shifts
-    show_all_shifts(shifts)
+    if result:
+        print(f"\nThe uncease string is found using Shift {shift_used}: {result}")
+    else:
+        print("\nNo valid shift found with a majority match in words.txt.")
+        show_all_shifts(shifts)
+
+
+def main():
+    clear_screen()
+    print("\033[94mCaesar Master\033[0m\n")
+    print("1. Encode text using Caesar cipher")
+    print("2. Decode Caesar cipher")
+    print("Press 1 or 2: ", end="", flush=True)
+    choice = get_single_key()
+    print(choice)
+
+    if choice == "1":
+        encode_menu()
+    elif choice == "2":
+        decode_menu()
+    else:
+        print("Invalid choice.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- handle missing `words.txt` with an informative message
- ignore punctuation while matching words and keep comparisons case-insensitive
- add helper utilities for clearing the screen and reading a single key
- display a blue "Caesar Master" header when starting
- menu selection now works on a single key press

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7f888a78832296adfaa2e24088f6